### PR TITLE
Fixed: XML dump takes care hidden view and not visible windows

### DIFF
--- a/lib/Cucumber.j
+++ b/lib/Cucumber.j
@@ -38,7 +38,8 @@ function dumpGuiObject(obj)
 {
     if (!obj ||
         ([obj respondsToSelector:@selector(isHidden)] && [obj isHidden]) ||
-        ([obj respondsToSelector:@selector(isVisible)] && ![obj isVisible]))
+        ([obj respondsToSelector:@selector(isVisible)] && ![obj isVisible]) ||
+        ([obj respondsToSelector:@selector(visibleRect)] && CGRectEqualToRect([obj visibleRect], CGRectMakeZero())))
         return '';
 
     var resultingXML = "<" + [obj className] + ">";


### PR DESCRIPTION
Previously, when dumping the xml, cucapp took care about hidden view and not visible window.
