### PR TITLE
New: Possibility to simulate a event CPMouseMoved over a point

### DIFF
--- a/lib/Cucumber.j
+++ b/lib/Cucumber.j
@@ -597,6 +597,25 @@ function dumpGuiObject(obj)
     [[CPRunLoop currentRunLoop] limitDateForMode:CPDefaultRunLoopMode];
 }
 
+- (void)simulateMouseMovedOnPoint:(CPArray)params
+{
+    var locationWindowPoint = CGPointMake(params.shift(), params.shift()),
+        modifierFlags = 0,
+        flags = params[0],
+        window = [CPApp keyWindow];
+
+    for (var i = 0; i < [flags count]; i++)
+    {
+        var flag = flags[i];
+        modifierFlags |= parseInt(flag);
+    }
+
+    var mouseMoved = [CPEvent mouseEventWithType:CPMouseMoved location:locationWindowPoint modifierFlags:modifierFlags
+        timestamp:[CPEvent currentTimestamp] windowNumber:[window windowNumber] context:nil eventNumber:-1 clickCount:1 pressure:0];
+
+    [CPApp sendEvent:mouseMoved];
+}
+
 - (void)_perfomMouseEventOnPoint:(CGPoint)locationWindowPoint toPoint:(CPView)locationWindowPoint2 window:(CPWindow)currentWindow eventType:(unsigned)anEventType numberOfClick:(int)numberOfClick modifierFlags:(CPArray)flags
 {
     var typeMouseDown = CPLeftMouseDown,
@@ -687,6 +706,7 @@ function dumpGuiObject(obj)
     [self setNeedsLayout];
     [self setNeedsDisplay:YES];
 }
+
 @end
 
 [Cucumber startCucumber];

--- a/lib/encumber.rb
+++ b/lib/encumber.rb
@@ -270,7 +270,6 @@ module Encumber
 
     def simulate_left_click_on_point x, y, flags
       result = command('simulateLeftClickOnPoint', x, y, flags)
-      raise "Point not found: #{result}" if result["result"] != 'OK'
     end
 
     def simulate_double_click xpath, flags
@@ -280,7 +279,6 @@ module Encumber
 
     def simulate_double_click_on_point x, y, flags
       result = command('simulateDoubleClick', x, y, flags)
-      raise "View not found: #{result}" if result!='OK'
     end
 
     def simulate_dragged_click_view_to_view xpath1, xpath2, flags
@@ -295,7 +293,6 @@ module Encumber
 
     def simulate_dragged_click_point_to_point x, y, x2, y2, flags
       result = command('simulateDraggedClickPointToPoint', x, y, x2, y2, flags)
-      raise "Point not found: #{result}" if result["result"] != 'OK'
     end
 
     def simulate_right_click xpath, flags
@@ -305,7 +302,10 @@ module Encumber
 
     def simulate_right_click_on_point x, y, flags
       result = command('simulateRightClickOnPoint', x, y, flags)
-      raise "Point not found: #{result}" if result["result"] != 'OK'
+    end
+
+    def simulate_mouse_moved_on_point x, y, flags
+      result = command('simulateMouseMovedOnPoint', x, y, flags)
     end
 
     def simulate_keyboard_event charac, flags


### PR DESCRIPTION
Previously it wasn't possible to simulate the event CPMouseMoved.
Now we can, and then simulate a mouseEntered and mouseExited in a Cappuccino application.

This PR fixs also some small issues about exception generated by ruby when simulating event on point and not views.
