### PR TITLE
Fixed: Cucumber+Extensions.j raises an Exception on Firefox

### DIFF
--- a/lib/server.rb
+++ b/lib/server.rb
@@ -129,11 +129,9 @@ module Encumber
 
             if ("#{use_cucapp_bundle}" == "no")
             {
-              objj_importFile("/Cucapp/lib/Cucumber.j");
-
-              setTimeout(function(){
-                try {objj_importFile("/features/support/Cucumber+Extensions.j")} catch (e) {}
-              },0);
+              objj_importFile("/Cucapp/lib/Cucumber.j", true, function() {
+                  try {objj_importFile("/features/support/Cucumber+Extensions.j")} catch (e) {}
+              });
             }
             else
             {


### PR DESCRIPTION
Previously, when using Cucapp with Firefox, Firefox raised a exception because Cucumber+Extensions was imported before that Cucumber.j was fuly imported.
Now it works well !
