### PR TITLE
Fixed: CPMouseMoved events are managed by Cappuccino

### DIFF
--- a/lib/Cucumber.j
+++ b/lib/Cucumber.j
@@ -98,6 +98,9 @@ function dumpGuiObject(obj)
         {
             var globalPoint = [obj superview] ? [[obj superview] convertPointToBase:frame.origin] : frame.origin;
 
+            globalPoint.x += [[obj window] frame].origin.x;
+            globalPoint.y += [[obj window] frame].origin.y;
+
             resultingXML += "<absoluteFrame>";
             resultingXML += "<x>" + globalPoint.x + "</x>";
             resultingXML += "<y>" + globalPoint.y + "</y>";

--- a/lib/encumber.rb
+++ b/lib/encumber.rb
@@ -194,14 +194,15 @@ module Encumber
     end
 
     def launch
-
       sleep 0.2 # there seems to be a timing issue. This little hack fixes it.
       Launchy.open("http://localhost:3000/cucumber.html" + self.make_url_params)
 
       startTime = Time.now
-      until command('launched') == "YES" || (Time.now-startTime<@timeout) do
+
+      while command('launched') == "NO" && (Time.now - startTime < @timeout) do
         # do nothing
       end
+
       raise "launch timed out " if Time.now-startTime>@timeout
 
       sleep 1


### PR DESCRIPTION
Previously, between two simulated events, Cucapp generated CPMouseMoved events in Cucumber.j. All of these events were generated in the same stack. This occured some display issues.

Now, cucapp will generate these events. Between two events, cucapp will send X rest calls to generate several CPMouseMoved events, therefore these events won't be in the same stack.
