### PR TITLE
Handle large responses from Cappuccino

### DIFF
--- a/lib/encumber.rb
+++ b/lib/encumber.rb
@@ -158,27 +158,27 @@ module Encumber
       data = nil
       CUCUMBER_REQUEST_QUEUE.push(command)
       CUCUMBER_RESPONSE_QUEUE.pop { |result|
-                if result
-                    data = result['rack.input'].read
-                end
-                th.wakeup
+          if result
+              data = result['rack.input'].read
+          end
+          th.wakeup
       }
       startTime = Time.now
       sleep @timeout
       raise "Command timed out" if Time.now-startTime>=@timeout
-            if data && !data.empty?
-                obj = JSON.parse(data)
-                if obj["error"]
-                    raise obj["error"]
-                else
-                    begin
-                        JSON.parse(obj["result"])
-                    rescue Exception => e
-                        obj["result"]
-                    end
-                end
-            else
-                nil
+      if data && !data.empty?
+          obj = JSON.parse(data)
+          if obj["error"]
+              raise obj["error"]
+          else
+              begin
+                  JSON.parse(obj["result"])
+              rescue Exception => e
+                  obj["result"]
+              end
+          end
+      else
+          nil
       end
     end
 


### PR DESCRIPTION
When the response to a request is big, thin returns a temp file instead of a string. To avoid the file being deleted before it's read, we read it in the callback function that is called when we receive the response.
