### PR TITLE
New: more informations when clicking on a view with the CLI

### DIFF
--- a/lib/Cucumber.j
+++ b/lib/Cucumber.j
@@ -35,9 +35,8 @@ function _addition_cpapplication_send_event_method()
 
         function(object, _cmd)
         {
-            if(object === CPApp)
+            if (object === CPApp)
             {
-
                 var event = arguments[2],
                     window = [event window];
 
@@ -45,16 +44,36 @@ function _addition_cpapplication_send_event_method()
                 {
                     var view = [window._windowView hitTest:[event locationInWindow]];
 
-                    if ([view respondsToSelector:@selector(cucappIdentifier)])
+                    CPLog.debug("A left click has been catched on the views (ascending order):");
+
+                    while(view)
                     {
-                        CPLog.debug("The cucappIdentifier of the targeted view is : " + [view cucappIdentifier]);
-                        console.error(view);
+                        _print_informations_of_view(view);
+                        view = [view superview];
                     }
                 }
             }
 
         return aFunction.apply(this, arguments);
         });
+}
+
+function _print_informations_of_view(aView)
+{
+    var keys = ["cucappIdentifier", "title", "identifier", "text", "placeholderString", "label", "tag", "objectValue"]
+
+    for (var i = 0; i < [keys count]; i++)
+    {
+        var key = keys[i],
+            selector = CPSelectorFromString(key);
+
+        if (![aView respondsToSelector:selector] || ![aView performSelector:selector] || (key === "tag" && [aView performSelector:selector] == -1))
+            continue;
+
+        CPLog.debug("The " + key + " of the targeted view is : " + [aView performSelector:selector]);
+        console.error(aView);
+        return;
+    }
 }
 
 function simulate_keyboard_event(character, flags)


### PR DESCRIPTION
Previously, when clicking a view we only displayed the informations of the first view caught.
Now we log the informations of the views caught for this click. It means we will display the first view, its parent, its parent and so on.
We will only display the view which have a cucappIdentifier, text, label, tag, title, objectValue, placeholderString or identifier.